### PR TITLE
Fix: misleading error logs

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2039,8 +2039,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits[%zu] is %lu but it should be should be %u",
-                   i, consistency_limits[i].size(), sub_groups[i]->getVariableCount());
+      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits[%zu] is %lu but it should be should be %u", i,
+                   consistency_limits[i].size(), sub_groups[i]->getVariableCount());
       return false;
     }
   }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2039,8 +2039,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits is %zu but it should be should be %u", i,
-                   sub_groups[i]->getVariableCount());
+      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits[%zu] is %lu but it should be should be %u",
+                   i, consistency_limits[i].size(), sub_groups[i]->getVariableCount());
       return false;
     }
   }


### PR DESCRIPTION
### Description

misleading log message for  RobotState::setFromIKSubgroups() when checking consistency_limits size

before:
![screenshot-20250123-160345](https://github.com/user-attachments/assets/345983f5-580a-4b34-bf5d-2dcbe571dd31)

fixed:
![fixed](https://github.com/user-attachments/assets/fa5a3adc-80d3-4d82-b265-fd3c98e0e6b4)


